### PR TITLE
[docs] API update notice + call for sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ src/disassembler/IDA/*.pyc
 /Karta.egg-info/*
 
 docs/_build/*
+docs/_build/*/*
 docs/_static/*
 docs/_templates/*
 /*.pyc

--- a/docs/Compiling a configuration.md
+++ b/docs/Compiling a configuration.md
@@ -50,3 +50,9 @@ The script will ask you for the path to your disassembler (IDA), and will sugges
 Storing the config file
 -----------------------
 In the end, a new ```*.json``` file will be generated (using the library name + version), and it should be stored together with the rest of the configuration files in the ```configs``` directory.
+
+Uploading the config file back to the community :)
+--------------------------------------------------
+So, you created a new config file and it works on your setup, Good Job :)
+
+Please consider submitting it to the community collection of configurations and fingerprints. Feel free to submit it as a pull request for now, and in the future we might update it to a separate repository.

--- a/docs/Supporting a new library.md
+++ b/docs/Supporting a new library.md
@@ -13,3 +13,9 @@ Adding a new *.py file for the identification script is rather simple. The neede
 1.  Update the ```NAME``` variable, with an exact string name (case sensitive)
 1.  Update the logic of ```searchLib()``` method - currently based on a basic string search
 1.  If needed, update the logic of the ```identifyVersions()``` method
+
+Sharing with the community :)
+-----------------------------
+So, you just added support for a new library, and it worked on your setup. Good Job :)
+
+Please consider submitting it to the community collection of configurations and fingerprints. Feel free to submit it as a pull request for now, and in the future we might update it to a separate repository.

--- a/docs/disassembler.md
+++ b/docs/disassembler.md
@@ -11,6 +11,7 @@ Since **Karta** was developed to be modular, and because one of our researchers 
 The  ```src\disassembler\disas_api.py``` file defines the interface needed by **Karta**, and can be split to 3 main parts (as can be seen inside the folder ```src\disassembler\IDA```):
 1. Basic API - finding the name of a function, getting a segment list, etc.
 2. Cmd API - functionality for activating the disassembler from the command line.
-3. Analysis API - core logic needed for creating the canonical representation of a function.
+3. Verifier API - key integration point for the factory to be able to decide inside which disassembler are we being run at the current moment.
+4. Analysis API - core logic needed for creating the canonical representation of a function.
 
-While the first 2 parts can be easily implemented as empty adapters without any logic, the 3rd part is a bit more complex. We recommend developers to read the code from  ``` src\disassembler\IDA\ida_analysis_api.py``` as an example implementation, when trying to implement the same functionality in the added disassembler.
+While the first 3 parts can be easily implemented as empty adapters without any logic, the 4th part is a bit more complex. We recommend developers to read the code from  ``` src\disassembler\IDA\ida_analysis_api.py``` as an example implementation, when trying to implement the same functionality in the added disassembler.


### PR DESCRIPTION
Updated the new API chnage for DisasVerifier.
Under "supporting a new library" and under "compiling a new config" added a call for sharing back the results with us, as requested in issue #37.